### PR TITLE
Point to the new docs site instead of the wiki

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -31,9 +31,9 @@ The Fedora-specific Asahi discussions take place in Matrix on Fedora infra:
 * [#asahi-devel:fedoraproject.org](https://matrix.to/#/#asahi-devel:fedoraproject.org) - Fedora Asahi Development. IRC bridge: #fedora-asahi-dev
 * [#asahi:fedoraproject.org](https://matrix.to/#/#asahi:fedoraproject.org) - Fedora Asahi general discussion/support
 
-## Wiki
+## Documentation
 
-Our working documentation is maintained in a [GitHub Wiki](https://github.com/AsahiLinux/docs/wiki/).
+Our working documentation is maintained in a [documentation site](/docs) built from [GitHub](https://github.com/AsahiLinux/docs) using [MkDocs](https://mkdocs.org).
 
 ## Mastodon (Fediverse)
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -87,8 +87,8 @@
     </div>
     <div class="documentation-card center-card">
         <i class="big-icon fas fa-book-open"></i>
-        <p>We are documenting the Apple Silicon platform on our GitHub wiki.</p>
-        <a href="https://github.com/AsahiLinux/docs/wiki" class="more">Visit the Wiki<i class="fas fa-angle-right more"></i></a>
+        <p>We are documenting the Apple Silicon platform on our documentation website.</p>
+        <a href="/docs" class="more">Read the documentation<i class="fas fa-angle-right more"></i></a>
     </div>
 </section>
 <script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -46,8 +46,8 @@
                 <li><a href="/community">Community</a></li>
                 <li><a href="/contribute">Contribute</a></li>
                 <li><a href="/governance">Governance</a></li>
+                <li><a href="/docs">Documentation</a></li>
                 <li><a href="https://github.com/AsahiLinux">GitHub</a></li>
-                <li><a href="https://github.com/AsahiLinux/docs/wiki">Wiki</a></li>
                 <li><a href="/blog">Blog</a></li>
                 <li><a href="/support">Donate</a></li>
             </ul>


### PR DESCRIPTION
There's still plenty of references to individual pages here and there but this is a good start.