### PR TITLE
microphone is not supported yet on macbook pro 13inch

### DIFF
--- a/content/fedora.md
+++ b/content/fedora.md
@@ -151,7 +151,7 @@ With our in-house [Bankstown](https://github.com/chadmed/bankstown) bass boost t
                 <div class="sup">Touch Bar†</div>
                 <div class="sup">Headset Jack</div>
                 <div class="sup">Speakers</div>
-                <div class="sup">Microphone</div>
+                <div class="sup">Microphone‡</div>
                 <div class="sup">Camera</div>
                 <div class="sup">MagSafe‡</div>
                 <div class="sup">USB Type C (USB 3.0)</div>


### PR DESCRIPTION
via https://github.com/AsahiLinux/asahi-audio/tree/b82111196a3bbb2ca9b676b3b2fd47426d8e2af7 (latest SHA as of now)
- under "Currently Supported Devices (microphones)", **MacBook Pro (13-inch, M1/M2, 2020/2022)** is not listed
